### PR TITLE
Create new custom event

### DIFF
--- a/Async/Topics.php
+++ b/Async/Topics.php
@@ -18,6 +18,7 @@ class Topics
     const WEBHOOK_ENTITY_CREATE = 'aligent.webhook.entity.create';
     const WEBHOOK_ENTITY_UPDATE = 'aligent.webhook.entity.update';
     const WEBHOOK_ENTITY_DELETE = 'aligent.webhook.entity.delete';
+    const WEBHOOK_ENTITY_CUSTOM = 'aligent.webhook.entity.custom';
 
     const EVENT_MAP = [
         WebhookConfigProvider::UPDATE => self::WEBHOOK_ENTITY_UPDATE,

--- a/Async/WebhookEntityProcessor.php
+++ b/Async/WebhookEntityProcessor.php
@@ -29,6 +29,7 @@ class WebhookEntityProcessor extends AbstractRetryableProcessor implements Topic
         Topics::WEBHOOK_ENTITY_UPDATE => WebhookConfigProvider::UPDATE,
         Topics::WEBHOOK_ENTITY_DELETE => WebhookConfigProvider::DELETE,
         Topics::WEBHOOK_ENTITY_CREATE => WebhookConfigProvider::CREATE,
+        Topics::WEBHOOK_ENTITY_CUSTOM => WebhookConfigProvider::CUSTOM,
     ];
 
     /**
@@ -119,6 +120,7 @@ class WebhookEntityProcessor extends AbstractRetryableProcessor implements Topic
             $this->logger->error(
                 $message,
                 [
+                    
                     'channelId' => $channel->getId(),
                     'channel' => $channel->getName(),
                     'topic' => $topic,
@@ -140,6 +142,7 @@ class WebhookEntityProcessor extends AbstractRetryableProcessor implements Topic
             Topics::WEBHOOK_ENTITY_CREATE,
             Topics::WEBHOOK_ENTITY_DELETE,
             Topics::WEBHOOK_ENTITY_UPDATE,
+            Topics::WEBHOOK_ENTITY_CUSTOM,
         ];
     }
 
@@ -153,7 +156,7 @@ class WebhookEntityProcessor extends AbstractRetryableProcessor implements Topic
     {
         $entity = $this->registry->getRepository($data['class'])->find($data['id']);
 
-        if ($event === WebhookConfigProvider::CREATE) {
+        if (in_array($event, [WebhookConfigProvider::CREATE, WebhookConfigProvider::CUSTOM])) {
             $changeSet = [];
         } else {
             // extract all of the before values from the change set

--- a/Async/WebhookEntityProcessor.php
+++ b/Async/WebhookEntityProcessor.php
@@ -32,20 +32,9 @@ class WebhookEntityProcessor extends AbstractRetryableProcessor implements Topic
         Topics::WEBHOOK_ENTITY_CUSTOM => WebhookConfigProvider::CUSTOM,
     ];
 
-    /**
-     * @var WebhookConfigProvider
-     */
-    protected $configProvider;
-
-    /**
-     * @var WebhookTransport
-     */
-    protected $transport;
-
-    /**
-     * @var SerializerInterface
-     */
-    protected $serializer;
+    protected WebhookTransport $transport;
+    protected SerializerInterface $serializer;
+    protected WebhookConfigProvider $configProvider;
 
     /**
      * @param SerializerInterface $serializer
@@ -83,7 +72,7 @@ class WebhookEntityProcessor extends AbstractRetryableProcessor implements Topic
     /**
      * @inheritDoc
      */
-    public function execute(MessageInterface $message)
+    public function execute(MessageInterface $message): string
     {
         $data = JSON::decode($message->getBody());
         $topic = $message->getProperty(Config::PARAMETER_TOPIC_NAME);
@@ -136,7 +125,7 @@ class WebhookEntityProcessor extends AbstractRetryableProcessor implements Topic
     /**
      * @inheritDoc
      */
-    public static function getSubscribedTopics()
+    public static function getSubscribedTopics(): array
     {
         return [
             Topics::WEBHOOK_ENTITY_CREATE,
@@ -149,10 +138,10 @@ class WebhookEntityProcessor extends AbstractRetryableProcessor implements Topic
     /**
      * @param string $event
      * @param array $data
-     * @return array
+     * @return array<string, mixed>
      * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
      */
-    protected function buildPayload(string $event, array $data)
+    protected function buildPayload(string $event, array $data): array
     {
         $entity = $this->registry->getRepository($data['class'])->find($data['id']);
 

--- a/Form/Type/WebhookTransportSettingsType.php
+++ b/Form/Type/WebhookTransportSettingsType.php
@@ -51,9 +51,10 @@ class WebhookTransportSettingsType extends AbstractType
 
     /**
      * @param FormBuilderInterface $builder
-     * @param array $options
+     * @param array<string, mixed> $options
+     * @return void
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(
@@ -127,9 +128,9 @@ class WebhookTransportSettingsType extends AbstractType
     }
 
     /**
-     * @return array
+     * @return array<string, string>
      */
-    protected function getEntityList()
+    protected function getEntityList(): array
     {
         $em = $this->registry->getManager();
         $entities = [];
@@ -143,9 +144,9 @@ class WebhookTransportSettingsType extends AbstractType
     }
 
     /**
-     * @return array
+     * @return array<string, string>
      */
-    protected function getEventsList()
+    protected function getEventsList(): array
     {
         /** @var array<string, string> $events */
         $events = [];
@@ -162,8 +163,9 @@ class WebhookTransportSettingsType extends AbstractType
     }
     /**
      * @param OptionsResolver $resolver
+     * @return void
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefault('data_class', WebhookTransport::class);
     }

--- a/Integration/WebhookChannel.php
+++ b/Integration/WebhookChannel.php
@@ -21,6 +21,6 @@ class WebhookChannel implements ChannelInterface
      */
     public function getLabel()
     {
-        return 'aligent.webhook.channel.label';
+        return 'aligent.async.channel.label';
     }
 }

--- a/Integration/WebhookChannel.php
+++ b/Integration/WebhookChannel.php
@@ -19,7 +19,7 @@ class WebhookChannel implements ChannelInterface
     /**
      * @inheritDoc
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         return 'aligent.async.channel.label';
     }

--- a/Integration/WebhookTransport.php
+++ b/Integration/WebhookTransport.php
@@ -104,7 +104,7 @@ class WebhookTransport implements TransportInterface
      */
     public function getLabel()
     {
-        return 'aligent.webhook.transport.label';
+        return 'aligent.async.transport.label';
     }
 
     /**

--- a/Integration/WebhookTransport.php
+++ b/Integration/WebhookTransport.php
@@ -14,33 +14,20 @@ namespace Aligent\AsyncEventsBundle\Integration;
 
 use Aligent\AsyncEventsBundle\Form\Type\WebhookTransportSettingsType;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
 use Oro\Bundle\IntegrationBundle\Entity\Channel;
 use Oro\Bundle\IntegrationBundle\Entity\Transport;
 use Oro\Bundle\IntegrationBundle\Provider\TransportInterface;
 use Oro\Bundle\SecurityBundle\Encoder\SymmetricCrypterInterface;
 use Psr\Log\LoggerInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class WebhookTransport implements TransportInterface
 {
-    /**
-     * @var SymmetricCrypterInterface
-     */
-    protected $encoder;
-
-    /**
-     * @var LoggerInterface
-     */
-    protected $logger;
-
-    /**
-     * @var Channel
-     */
-    protected $channel;
-
-    /**
-     * @var Client
-     */
-    protected $client;
+    protected Client $client;
+    protected Channel $channel;
+    protected LoggerInterface $logger;
+    protected SymmetricCrypterInterface $encoder;
 
     /**
      * AntavoRestTransport constructor.
@@ -56,7 +43,7 @@ class WebhookTransport implements TransportInterface
     /**
      * @inheritDoc
      */
-    public function init(Transport $transportEntity)
+    public function init(Transport $transportEntity): void
     {
         $settings = $transportEntity->getSettingsBag();
         $this->channel = $transportEntity->getChannel();
@@ -84,11 +71,11 @@ class WebhookTransport implements TransportInterface
 
     /**
      * @param string $method
-     * @param array $payload
-     * @return \Psr\Http\Message\ResponseInterface
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @param array<string, mixed> $payload
+     * @return ResponseInterface
+     * @throws GuzzleException
      */
-    public function sendWebhookEvent($method = 'POST', $payload = [])
+    public function sendWebhookEvent(string $method = 'POST', array $payload = []): ResponseInterface
     {
         return $this->client->request(
             $method,
@@ -102,7 +89,7 @@ class WebhookTransport implements TransportInterface
     /**
      * @inheritDoc
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         return 'aligent.async.transport.label';
     }
@@ -110,7 +97,7 @@ class WebhookTransport implements TransportInterface
     /**
      * @inheritDoc
      */
-    public function getSettingsFormType()
+    public function getSettingsFormType(): string
     {
         return WebhookTransportSettingsType::class;
     }
@@ -118,7 +105,7 @@ class WebhookTransport implements TransportInterface
     /**
      * @inheritDoc
      */
-    public function getSettingsEntityFQCN()
+    public function getSettingsEntityFQCN(): string
     {
         return \Aligent\AsyncEventsBundle\Entity\WebhookTransport::class;
     }

--- a/Provider/WebhookConfigProvider.php
+++ b/Provider/WebhookConfigProvider.php
@@ -4,6 +4,7 @@ namespace Aligent\AsyncEventsBundle\Provider;
 
 use Doctrine\Common\Cache\CacheProvider;
 use Oro\Bundle\IntegrationBundle\Entity\Channel;
+use Oro\Bundle\IntegrationBundle\Entity\Transport;
 use Symfony\Bridge\Doctrine\ManagerRegistry;
 
 /**
@@ -25,15 +26,8 @@ class WebhookConfigProvider
     // Cache Keys
     const CONFIG_CACHE_KEY = 'WebhookConfig';
 
-    /**
-     * @var ManagerRegistry
-     */
-    protected $registry;
-
-    /**
-     * @var CacheProvider
-     */
-    protected $cache;
+    protected CacheProvider $cache;
+    protected ManagerRegistry $registry;
 
     /**
      * WebhookEntityProvider constructor.
@@ -48,8 +42,9 @@ class WebhookConfigProvider
 
     /**
      * Initialize the webhook config cache
+     * @return array<string, array<string, array<int>>>
      */
-    protected function getWebhookConfig()
+    protected function getWebhookConfig(): array
     {
         if ($webhookConfig = $this->cache->fetch(self::CONFIG_CACHE_KEY)) {
             return $webhookConfig;
@@ -76,20 +71,20 @@ class WebhookConfigProvider
 
     /**
      * @param $class
-     * @return array|null
+     * @return array<string, array<int>>|null
      */
-    public function getEntityConfig($class)
+    public function getEntityConfig($class): ?array
     {
         $config = $this->getWebhookConfig();
         return $config[$class] ?? null;
     }
 
     /**
-     * @param $class
-     * @param $event
+     * @param string $class
+     * @param string $event
      * @return boolean
      */
-    public function isManaged($class, $event)
+    public function isManaged(string $class, string $event): bool
     {
         $entityConfig = $this->getEntityConfig($class);
         if (!$entityConfig) {
@@ -101,11 +96,11 @@ class WebhookConfigProvider
 
     /**
      * Returns a list of channel id's that wish to be notified of this event for this entity
-     * @param $class
-     * @param $event
+     * @param string $class
+     * @param string $event
      * @return int[]
      */
-    public function getNotificationChannels($class, $event)
+    public function getNotificationChannels(string $class, string $event): array
     {
         $entityConfig = $this->getEntityConfig($class);
         if ($entityConfig == null) {
@@ -116,10 +111,10 @@ class WebhookConfigProvider
 
     /**
      * Convert the webhook config to an easily queried format
-     * @param array $config
-     * @return array
+     * @param array<int, Transport> $config
+     * @return array<string, array<string, array<int>>>
      */
-    protected function normalizeConfig(array $config)
+    protected function normalizeConfig(array $config): array
     {
         $normalizedConfig = [];
         foreach ($config as $id => $webhookTransport) {

--- a/Provider/WebhookConfigProvider.php
+++ b/Provider/WebhookConfigProvider.php
@@ -20,6 +20,7 @@ class WebhookConfigProvider
     const CREATE = 'create';
     const UPDATE = 'update';
     const DELETE = 'delete';
+    const CUSTOM = 'custom';
 
     // Cache Keys
     const CONFIG_CACHE_KEY = 'WebhookConfig';
@@ -107,6 +108,9 @@ class WebhookConfigProvider
     public function getNotificationChannels($class, $event)
     {
         $entityConfig = $this->getEntityConfig($class);
+        if ($entityConfig == null) {
+            return [];
+        }
         return $entityConfig[$event];
     }
 

--- a/Provider/WebhookCustomEventInterface.php
+++ b/Provider/WebhookCustomEventInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @category  Aligent
+ * @author    Bruno Pasqualini <bruno.pasqualini@aligent.com.au>
+ * @copyright 2023 Aligent Consulting.
+ * @link      http://www.aligent.com.au/
+ */
+
+namespace Aligent\AsyncEventsBundle\Provider;
+
+interface WebhookCustomEventInterface
+{
+
+    /**
+     * @return string
+     */
+    public static function getTranslationName(): string;
+
+    /**
+     * @return string
+     */
+    public static function getKey(): string;
+}

--- a/Provider/WebhookCustomEventsProvider.php
+++ b/Provider/WebhookCustomEventsProvider.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @category  Aligent
+ * @author    Bruno Pasqualini <bruno.pasqualini@aligent.com.au>
+ * @copyright 2023 Aligent Consulting.
+ * @link      http://www.aligent.com.au/
+ */
+
+namespace Aligent\AsyncEventsBundle\Provider;
+
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class WebhookCustomEventsProvider implements WebhookCustomEventsProviderInterface
+{
+    /**
+     * @var iterable<WebhookCustomEventsProviderInterface>
+     */
+    protected iterable $customEvents;
+
+    /**
+     * @param WebhookCustomEventsProviderInterface[]|iterable $customEvents
+     */
+    public function __construct(iterable $customEvents)
+    {
+        $this->customEvents = $customEvents;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCustomEvents(): iterable
+    {
+        return $this->customEvents;
+    }
+}

--- a/Provider/WebhookCustomEventsProviderInterface.php
+++ b/Provider/WebhookCustomEventsProviderInterface.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @category  Aligent
+ * @author    Bruno Pasqualini <bruno.pasqualini@aligent.com.au>
+ * @copyright 2023 Aligent Consulting.
+ * @link      http://www.aligent.com.au/
+ */
+
+namespace Aligent\AsyncEventsBundle\Provider;
+
+interface WebhookCustomEventsProviderInterface
+{
+    /**
+     * @return iterable<WebhookCustomEventInterface>
+     */
+    public function getCustomEvents(): iterable;
+}

--- a/Provider/WebhookIntegrationProvider.php
+++ b/Provider/WebhookIntegrationProvider.php
@@ -19,15 +19,8 @@ use Symfony\Bridge\Doctrine\ManagerRegistry;
 
 class WebhookIntegrationProvider
 {
-    /**
-     * @var ManagerRegistry
-     */
-    protected $registry;
-
-    /**
-     * @var WebhookTransport
-     */
-    protected $transport;
+    protected ManagerRegistry $registry;
+    protected WebhookTransport $transport;
 
     /**
      * WebhookIntegrationProvider constructor.

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -10,8 +10,14 @@ services:
   Aligent\AsyncEventsBundle\Form\Type\WebhookTransportSettingsType:
     arguments:
       - '@doctrine'
+      - '@translator'
+      - '@Aligent\AsyncEventsBundle\Provider\WebhookCustomEventsProvider'
     tags:
       - { name: form.type }
+
+  Aligent\AsyncEventsBundle\Provider\WebhookCustomEventsProvider:
+    arguments:
+      - !tagged_iterator aligent_async_events.custom_events
 
   # Caches
   aligent_webhook.config.cache:

--- a/Resources/translations/messages.en.yml
+++ b/Resources/translations/messages.en.yml
@@ -1,5 +1,8 @@
-aligent.webhook.channel.label: Webhook
-aligent.webhook.webhooktransport.entity_label: Webhook Transport
+aligent.async.channel.label: Webhook
+aligent.async.transport.label: Webhook Transport
+aligent.async.transport.form.event.create: Create
+aligent.async.transport.form.event.update: Update
+aligent.async.transport.form.event.delete: Delete
 aligent.asyncevents.failedjob.entity_plural_label: Failed Jobs
 aligent.async.failedjob.entity.plural_label: Failed Jobs
 aligent.async.failedjob.retry.label: Retry


### PR DESCRIPTION
This PR adds a new a custom event that allows webhooks/integrations to be triggered manually. This is useful when we want to to set up a webhook/integration that shouldn't be triggered automatically by the system when one of the default entity events present in this bundle takes places such as `CREATE`, `UPDATE`, `DELETE`.

The following code shows how to make use of this functionality by creating a custom event that would trigger a webhook when an Oro payment transaction is completed.

### 1. Create a webhook custom event

**services.yml**
```
  MyBundle\Webhook\WebhookCustomEventPaymentTransactionComplete:
    tags:
      - { name: aligent_async_events.custom_events }
```

**WebhookCustomEventPaymentTransactionComplete** class
```
class WebhookCustomEventPaymentTransactionComplete implements WebhookCustomEventInterface
{
    private const PAYMENT_TRANSACTION_COMPLETE = 'payment_complete';
    private const TRANSLATION_EVENT_NAME = 'mybundle.async.transport.form.custom_event.payment_transaction_complete';

    /**
     * @inheritDoc
     */
    public static function getTranslationName(): string
    {
        return self::TRANSLATION_EVENT_NAME;
    }

    /**
     * @inheritDoc
     */
    public static function getKey(): string
    {
        return self::PAYMENT_TRANSACTION_COMPLETE;
    }
}
```

**messages.en.yml**
```
mybundle.async.transport.form.custom_event.payment_transaction_complete: Custom - Payment Transaction Complete
```


### 2. Once the above has been implemented, you should see your new custom event as a option in the event dropdown
![image](https://github.com/aligent/oro-async-bundle/assets/95195161/f0227393-500d-410a-81ea-87c03b60840c)


### 3. Listen to payment transactions
```
  MyBundle\EventListener\PaymentTransactionListener:
    arguments:
      - '@oro_message_queue.client.message_producer'
      - '@Aligent\AsyncEventsBundle\Provider\WebhookConfigProvider'
    tags:
      - { name: kernel.event_listener, event: oro_payment.event.transaction_complete, method: onTransactionComplete, priority: -256 }
```


### 4. Trigger webhook custom event
```
        $webhookEntityConfig = $this->webhookConfigProvider->getNotificationChannels(
            Order::class,
            WebhookCustomEventPaymentTransactionComplete::getKey()
        );

        foreach ($webhookEntityConfig as $channelId) {
            $this->producer->send(
                Topics::WEBHOOK_ENTITY_CUSTOM,
                [
                    'class' => Order::class,
                    'id' => ['id' => $order->getId()],
                    'channelId' => $channelId
                ]
            );
        }
```