### PR TITLE
Hotfix/remove deleted channel from cache

### DIFF
--- a/EventListener/WebhookConfigCacheEventListener.php
+++ b/EventListener/WebhookConfigCacheEventListener.php
@@ -42,4 +42,15 @@ class WebhookConfigCacheEventListener
             $this->cache->deleteAll();
         }
     }
+
+    /**
+     * @param Transport $transport
+     * @param LifecycleEventArgs $args
+     */
+    public function postRemove(Transport $transport, LifecycleEventArgs $args)
+    {
+        if ($transport instanceof WebhookTransport) {
+            $this->cache->deleteAll();
+        }
+    }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -55,6 +55,7 @@ services:
       - [setConfigProvider, ['@Aligent\AsyncEventsBundle\Provider\WebhookConfigProvider']]
       - [setTransport, ['@Aligent\AsyncEventsBundle\Integration\WebhookTransport']]
       - [setSerializer, ['@oro_importexport.serializer']]
+      - [setCache, ['@aligent_webhook.config.cache']]
     tags:
       - { name: 'oro_message_queue.client.message_processor' }
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -48,6 +48,7 @@ services:
       - '@aligent_webhook.config.cache'
     tags:
       - { name: doctrine.orm.entity_listener, entity: 'Oro\Bundle\IntegrationBundle\Entity\Transport', event: postUpdate }
+      - { name: doctrine.orm.entity_listener, entity: 'Oro\Bundle\IntegrationBundle\Entity\Transport', event: postRemove }
 
   Aligent\AsyncEventsBundle\Async\WebhookEntityProcessor:
     parent: Aligent\AsyncEventsBundle\Async\AbstractRetryableProcessor


### PR DESCRIPTION
It was discovered  that when an webhook integration channel is being deleted and a new one created, it causes an error with a webhook.

After some investigation, a bug in the Aligent async bundle has been identified:

- Channel was cached and there’s no way to remove it from there. Cache is being cleared only on channel update, but not delete.
- `$channel->getName()` throws an error as channel doesn’t exist anymore.

